### PR TITLE
Patch for Cities with Spaces in them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ core/src/main/resources/javabot.properties
 *.ipr
 *.iws
 *.swp
+.settings
+.classpath
+.project

--- a/core/src/main/java/javabot/dao/impl/GoogleWeatherDaoImpl.java
+++ b/core/src/main/java/javabot/dao/impl/GoogleWeatherDaoImpl.java
@@ -9,6 +9,8 @@ import org.xml.sax.helpers.XMLReaderFactory;
 
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
+
+import java.net.URLEncoder;
 import java.util.HashMap;
 import java.util.Map;
 import javabot.model.Weather;
@@ -17,7 +19,8 @@ import org.springframework.stereotype.Component;
 
 /**
  * Implements a weather service Dao using Google's weather API
- * 
+ *
+ * @author Craig Tataryn &lt;craiger@tataryn.net&gt;
  */
 @Component
 public class GoogleWeatherDaoImpl implements WeatherDao {
@@ -29,7 +32,7 @@ public class GoogleWeatherDaoImpl implements WeatherDao {
         try {
             XMLReader reader = XMLReaderFactory.createXMLReader();
             reader.setContentHandler(handler); 
-            reader.parse(new InputSource(new URL(API_URL + place)
+            reader.parse(new InputSource(new URL(API_URL + URLEncoder.encode(place, "UTF-8"))
                         .openStream()));
         } catch (Exception e) {
             //TODO proper logging/distinction between error vs no-data

--- a/core/src/main/java/javabot/dao/impl/GoogleWeatherSaxHandler.java
+++ b/core/src/main/java/javabot/dao/impl/GoogleWeatherSaxHandler.java
@@ -12,7 +12,8 @@ import javabot.model.Weather;
 
 /**
  * SAX handler for Google's weather API
- * 
+ *
+ * @author Craig Tataryn &lt;craiger@tataryn.net&gt;
  */
 public class GoogleWeatherSaxHandler extends DefaultHandler {
     private boolean collectData;

--- a/core/src/test/java/javabot/operations/WeatherOperationTest.java
+++ b/core/src/test/java/javabot/operations/WeatherOperationTest.java
@@ -21,4 +21,11 @@ public class WeatherOperationTest extends BaseOperationTest {
         super.scanForResponse("~weather lajdlfjlasjdf", "only places on Earth");
 
     }
+
+    @Test
+    public void cityWithSpaces() throws Exception {
+        super.scanForResponse("~weather New York", "Weather for");
+
+    }
+
 }


### PR DESCRIPTION
Added URLEncoding for cities with spaces in them.  Couldn't actually test this locally though, after I last fetched from your original I started getting this:

Caused by: java.lang.NullPointerException
    at javabot.operations.OperationComparator.compare(OperationComparator.java:8)

That's the same error I was getting before submitting this patch:

https://github.com/evanchooly/javabot/commit/735163a85f321029dc70568ef7d383838b09a5e0

So not sure what's going on :(
