### PR TITLE
patched javabot to look up user/nick with case insensitive

### DIFF
--- a/core/src/main/java/javabot/Javabot.java
+++ b/core/src/main/java/javabot/Javabot.java
@@ -442,7 +442,7 @@ public class Javabot implements ApplicationContextAware {
 
   public boolean userIsOnChannel(final String nick, final String channel) {
     for (final User user : pircBot.getUsers(channel)) {
-      if (user.getNick().equals(nick)) {
+      if (user.getNick().equalsIgnoreCase(nick)) {
         return true;
       }
     }


### PR DESCRIPTION
- modified the userIsOnChannel method to be case insensitive. This would help allow for case insensitivity when looking up users especially for factoid operations.

Example: With a User topriddy. Previously, "tell Topriddy about log". would return the user "Topriddy" is not ion channel. With the new modification, javabot would be able to lookup user correctly.

Thanks.
