### PR TITLE
fixed jboss repo url

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <repository>
             <id>repository.jboss.org</id>
             <name>JBoss Maven Repository</name>
-            <url>http://repository.jboss.org/maven2</url>
+            <url>http://repository.jboss.org/nexus/content/groups/public-jboss/</url>
         </repository>
         <repository>
             <id>JBoss</id>


### PR DESCRIPTION
http://repository.jboss.org/maven2 has been broken for the public for a while.  See https://community.jboss.org/wiki/MavenSettings
