### PR TITLE
Escape factoid values on web display

### DIFF
--- a/core/src/main/resources/factoids.ftl
+++ b/core/src/main/resources/factoids.ftl
@@ -19,7 +19,7 @@
             </#if>
         ${factoid.name}
         </td>
-        <td>${factoid.value}</td>
+        <td>${factoid.value?html}</td>
         <td>${factoid.userName}</td>
         <td class="right">${format(factoid.updated)}</td>
     </tr>


### PR DESCRIPTION
Factoid values should be escaped on the "factoids" web page to make sure that prefixes such as `<see>` are visible to the user. 

Note that the lack of escaping also represents an XSS vulnerability. This PR makes no effort to ensure that other user input across javabot's web UI is escaped. These vulnerabilities should also be addressed.