### PR TITLE
Fixing javadoc test paths for 1.8 (may be windows-specific)

### DIFF
--- a/src/main/kotlin/javabot/model/ApiEvent.kt
+++ b/src/main/kotlin/javabot/model/ApiEvent.kt
@@ -25,8 +25,9 @@ class ApiEvent : AdminEvent {
 
     companion object {
         fun locateJDK(): String {
+            val jreRegex = Regex(".*[/\\\\]jre$")
             var property = System.getProperty("java.home")
-            if (property.endsWith("/jre")) {
+            if (property.matches(jreRegex)) {
                 property = property.dropLast(4)
             }
             return File(property, "src.zip").toURI().toURL().toString()

--- a/src/test/kotlin/javabot/javadoc/JavadocParserTest.kt
+++ b/src/test/kotlin/javabot/javadoc/JavadocParserTest.kt
@@ -19,9 +19,15 @@ class JavadocParserTest : BaseTest() {
     fun testBuildHtml() {
         val downloadUrl = ApiEvent.locateJDK()
         val file = downloadUrl.downloadZip(File("/tmp/JDK.jar"))
-        parser.buildHtml(JavadocApi("JDK", "${config.url()}/javadoc/JDK", "", "", ""), file, listOf("java", "javax"))
-
-        val applet = File("javadoc/JDK/java/applet/Applet.html")
+        // on windows this seems to be in javadoc/JDK/1.8 ---- MAY BE DIFFERENT ON DIFFERENT OSES.
+        // if so, we need to detect the 'problem' and remove the 1.8/ if detected.
+        val appletFilename = "javadoc/JDK/1.8/java/applet/Applet.html"
+        var applet = File(appletFilename)
+        if (!applet.exists()) {
+            parser.buildHtml(JavadocApi("JDK", "${config.url()}/javadoc/JDK/1.8", "", "", ""), file, listOf("java", "javax"))
+        }
+        // not sure if this resets without instantiation or not.
+        applet = File(appletFilename)
         Assert.assertTrue(applet.exists())
     }
 }


### PR DESCRIPTION
Fixes #152