### PR TITLE
Fixing: Factoids are overwritten even without ~no,

### DIFF
--- a/src/main/kotlin/javabot/operations/AddFactoidOperation.kt
+++ b/src/main/kotlin/javabot/operations/AddFactoidOperation.kt
@@ -59,7 +59,7 @@ class AddFactoidOperation @Inject constructor(bot: Javabot, adminDao: AdminDao,
                     } else {
                         factoid = factoidDao.getFactoid(key)
                         if (factoid != null) {
-                            reponses.add(Message(event, Sofia.factoidExists(factoid.name, event.user.nick)))
+                            responses.add(Message(event, Sofia.factoidExists(factoid.name, event.user.nick)))
                         } else {
                             factoid = Factoid(name, userName = event.user.nick)
                             factoid.name = factoid.name.dropLastWhile { it in arrayOf('.', '?', '!') }


### PR DESCRIPTION
When typing ~foo is bar, even if foo already exists, it updates; this bugfix corrects this behaviour. There's also a wonkiness without lowercasing keys, which is done for ~foo is bar but not for ~no, foo is bar. Fixed that too.