### PR TITLE
171 allow say for ops only

### DIFF
--- a/src/main/kotlin/javabot/operations/LinksOperation.kt
+++ b/src/main/kotlin/javabot/operations/LinksOperation.kt
@@ -133,9 +133,9 @@ class LinksOperation @Inject constructor(bot: Javabot,
     }
 
     private fun formatPastTense(input: String): String {
-        val verb=input.toLowerCase()
+        val verb = input.toLowerCase()
         return verb +
-                if("aeiou".indexOf(verb.last())!=-1) "d" else "ed"
+                if ("aeiou".indexOf(verb.last()) != -1) "d" else "ed"
     }
 
     private fun extractKey(tokens: MutableList<String>): String {
@@ -198,7 +198,7 @@ class LinksOperation @Inject constructor(bot: Javabot,
             val channel = extractChannel(tokens, needsChannel, event)
             val count = getOptionalCount(tokens)
             if (needsOps && !bot.adapter.isOp(event.user.nick, channel)) {
-                responses.add(Message(event, "You need to be an op on $channel to do that"))
+                responses.add(Message(event, Sofia.linksNotAnOp(channel)))
             } else {
                 responses.addAll(
                         listFunction(channel)

--- a/src/main/kotlin/javabot/operations/SayOperation.kt
+++ b/src/main/kotlin/javabot/operations/SayOperation.kt
@@ -10,7 +10,10 @@ class SayOperation @Inject constructor(bot: Javabot, adminDao: AdminDao) : BotOp
         val responses = arrayListOf<Message>()
         val message = event.value
         if (message.startsWith("say ")) {
-            responses.add(Message(event, message.substring("say ".length)))
+            // trims out a response if the channel name isn't empty AND the user isn't an op
+            if (event.channel == null || (bot.adapter.isOp(event.user.nick, event.channel.name))) {
+                responses.add(Message(event, message.substring("say ".length)))
+            }
         }
         return responses
     }

--- a/src/test/kotlin/javabot/operations/SayOperationsTest.kt
+++ b/src/test/kotlin/javabot/operations/SayOperationsTest.kt
@@ -2,15 +2,28 @@ package javabot.operations
 
 import com.google.inject.Inject
 import javabot.BaseTest
+import javabot.MockIrcAdapter
 import org.testng.Assert
+import org.testng.Assert.assertEquals
 import org.testng.annotations.Test
 
-@Test(groups = arrayOf("operations")) class SayOperationsTest : BaseTest() {
+@Test(groups = arrayOf("operations"))
+class SayOperationsTest : BaseTest() {
     @Inject
     private lateinit var operation: SayOperation
 
     fun testSay() {
-        var response = operation.handleMessage(message("~say MAGNIFICENT"))
-        Assert.assertEquals(response[0].value, "MAGNIFICENT")
+        val response = operation.handleMessage(message("~say MAGNIFICENT"))
+        assertEquals(response.size, 1)
+        assertEquals(response[0].value, "MAGNIFICENT")
     }
+
+    fun testSayNoOp() {
+        val mockIrcAdapter = bot.get().adapter as MockIrcAdapter
+        mockIrcAdapter.disableOperation("isOp")
+
+        val response = operation.handleMessage(message("~say MAGNIFICENT"))
+        assertEquals(response.size, 0)
+    }
+
 }


### PR DESCRIPTION
Limits "~say" to either privmsg (where it always works) *or* to ops on channel.