### PR TITLE
Fixes cosmetic issue where the karma message target should match the …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,10 @@ dependency-reduced-pom.xml
 *~
 Sofia.java
 /javadoc/
+
 # used by jottinger for local testing of mongo database
 /data/
+
+# build detritus
+build.log
+downloads/

--- a/src/main/kotlin/javabot/Message.kt
+++ b/src/main/kotlin/javabot/Message.kt
@@ -78,8 +78,8 @@ open class Message(val channel: Channel? = null, val user: JavabotUser, val valu
             }
             val space = target.indexOf(' ')
             val about = target.substring(space + 1)
-            val nick = target.substring(0, space)
-            return if (space >= 0) TellSubject(JavabotUser(nick), about.trim()) else null
+            //val nick = target.substring(0, space)
+            return if (space >= 0) TellSubject(JavabotUser(target.substring(0, space)), about.trim()) else null
         }
 
     }

--- a/src/main/kotlin/javabot/operations/KarmaOperation.kt
+++ b/src/main/kotlin/javabot/operations/KarmaOperation.kt
@@ -61,7 +61,7 @@ class KarmaOperation @Inject constructor(bot: Javabot, adminDao: AdminDao, var d
             }
             val nick: String =
                     try {
-                        val temp = message.substring(0, operationPointer).trim().toLowerCase()
+                        val temp = message.substring(0, operationPointer).trim()
                         // got an empty nick; spaces only?
                         if (temp.isEmpty()) {
                             // need to check for special case where bot was *addressed* for karma
@@ -88,10 +88,10 @@ class KarmaOperation @Inject constructor(bot: Javabot, adminDao: AdminDao, var d
                         }
                         increment = false
                     }
-                    var karma: Karma? = dao.find(nick)
+                    var karma: Karma? = dao.find(nick.toLowerCase())
                     if (karma == null) {
                         karma = Karma()
-                        karma.name = nick
+                        karma.name = nick.toLowerCase()
                     }
                     if (increment) {
                         karma.value = karma.value + 1
@@ -112,8 +112,9 @@ class KarmaOperation @Inject constructor(bot: Javabot, adminDao: AdminDao, var d
         val message = event.value
         val sender = event.user
         if (message.startsWith("karma ")) {
-            val nick = message.substring("karma ".length).toLowerCase()
-            val karma = dao.find(nick)
+            val nick = message.substring("karma ".length)
+            val normalizedNick=nick.toLowerCase()
+            val karma = dao.find(normalizedNick)
             if (karma != null) {
                 responses.add(Message(event, if (nick.equals(sender.nick, ignoreCase = true))
                     Sofia.karmaOwnValue(sender.nick, karma.value)

--- a/src/test/kotlin/javabot/operations/KarmaOperationTest.kt
+++ b/src/test/kotlin/javabot/operations/KarmaOperationTest.kt
@@ -29,21 +29,34 @@ class KarmaOperationTest @Inject constructor(val nickServDao: NickServDao,
         val target = "foo ${Date().time}"
         val karma = getKarma(target) + 1
         val response = operation.handleMessage(message("~${target} ++"))
-                assertEquals(response[0].value, Sofia.karmaOthersValue(target, karma, TEST_USER.nick))
+        assertEquals(response[0].value, Sofia.karmaOthersValue(target, karma, TEST_USER.nick))
         assertTrue(changeDao.findLog(Sofia.karmaChanged(TEST_USER.nick, target, karma, TEST_CHANNEL.name)))
         karmaDao.delete(karmaDao.find(target)?.id)
     }
 
+    fun caseInsensitiveKarma() {
+        val target1 = "foo ${Date().time}"
+        val target2 = target1.capitalize()
+        val karma = getKarma(target1) + 1
+        var response = operation.handleMessage(message("~${target1} ++"))
+        assertEquals(response[0].value, Sofia.karmaOthersValue(target1, karma, TEST_USER.nick))
+        assertTrue(changeDao.findLog(Sofia.karmaChanged(TEST_USER.nick, target1, karma, TEST_CHANNEL.name)))
+        response = operation.handleMessage(message("~${target2} ++"))
+        // should respond with the key that was PASSED IN, not the normalized version
+        assertEquals(response[0].value, Sofia.karmaOthersValue(target2, karma + 1, TEST_USER.nick))
+        assertTrue(changeDao.findLog(Sofia.karmaChanged(TEST_USER.nick, target1, karma + 1, TEST_CHANNEL.name)))
+        karmaDao.delete(karmaDao.find(target1)?.id)
+    }
+
     fun botNameWithKarmaWithAddress() {
-        val target = TEST_BOT_NICK
-        val karma = getKarma(target) + 1
-        val event = message("${TEST_BOT_NICK}: ${target}++", TEST_BOT_NICK)
+        val karma = getKarma(TEST_BOT_NICK) + 1
+        val event = message("${TEST_BOT_NICK}: ${TEST_BOT_NICK}++", TEST_BOT_NICK)
         val response = operation.handleMessage(event)
-        assertEquals(response[0].value, Sofia.karmaOthersValue(target, karma, TEST_USER.nick))
+        assertEquals(response[0].value, Sofia.karmaOthersValue(TEST_BOT_NICK, karma, TEST_USER.nick))
 
         bot.get().processMessage(event)
-        assertTrue(changeDao.findLog(Sofia.karmaChanged(TEST_USER.nick, target, karma, TEST_CHANNEL.name)))
-        karmaDao.delete(karmaDao.find(target)?.id)
+        assertTrue(changeDao.findLog(Sofia.karmaChanged(TEST_USER.nick, TEST_BOT_NICK, karma, TEST_CHANNEL.name)))
+        karmaDao.delete(karmaDao.find(TEST_BOT_NICK)?.id)
     }
 
     fun botNameWithKarma() {
@@ -87,7 +100,7 @@ class KarmaOperationTest @Inject constructor(val nickServDao: NickServDao,
         val target = "foo ${Date().time}"
         val karma = getKarma(target) + 1
         val response = operation.handleMessage(message("~${target} ++"))
-                assertEquals(response[0].value, Sofia.karmaOthersValue(target, karma, TEST_USER.nick))
+        assertEquals(response[0].value, Sofia.karmaOthersValue(target, karma, TEST_USER.nick))
         assertTrue(changeDao.findLog(Sofia.karmaChanged(TEST_USER.nick, target, karma, TEST_CHANNEL.name)))
         karmaDao.delete(karmaDao.find(target)?.id)
     }
@@ -96,7 +109,7 @@ class KarmaOperationTest @Inject constructor(val nickServDao: NickServDao,
         val target = "foo ${Date().time}"
         val karma = getKarma(target) + 1
         val response = operation.handleMessage(message("~${target}++ hey coolio"))
-                assertEquals(response[0].value, Sofia.karmaOthersValue(target, karma, TEST_USER.nick))
+        assertEquals(response[0].value, Sofia.karmaOthersValue(target, karma, TEST_USER.nick))
         assertTrue(changeDao.findLog(Sofia.karmaChanged(TEST_USER.nick, target, karma, TEST_CHANNEL.name)))
         karmaDao.delete(karmaDao.find(target)?.id)
     }
@@ -105,7 +118,7 @@ class KarmaOperationTest @Inject constructor(val nickServDao: NickServDao,
         val target = "a" // shortest possible name
         val karma = getKarma(target) + 1
         val response = operation.handleMessage(message("~${target}++"))
-                assertEquals(response[0].value, Sofia.karmaOthersValue(target, karma, TEST_USER.nick))
+        assertEquals(response[0].value, Sofia.karmaOthersValue(target, karma, TEST_USER.nick))
         assertTrue(changeDao.findLog(Sofia.karmaChanged(TEST_USER.nick, target, karma, TEST_CHANNEL.name)))
         karmaDao.delete(karmaDao.find(target)?.id)
     }
@@ -130,7 +143,7 @@ class KarmaOperationTest @Inject constructor(val nickServDao: NickServDao,
         val target = "${Date().time}"
         val karma = getKarma(target) + 1
         val response = operation.handleMessage(message("~${target}++"))
-                assertEquals(response[0].value, Sofia.karmaOthersValue(target, karma, TEST_USER.nick))
+        assertEquals(response[0].value, Sofia.karmaOthersValue(target, karma, TEST_USER.nick))
         assertTrue(changeDao.findLog(Sofia.karmaChanged(TEST_USER.nick, target, karma, TEST_CHANNEL.name)))
         karmaDao.delete(karmaDao.find(target)?.id)
     }
@@ -139,7 +152,7 @@ class KarmaOperationTest @Inject constructor(val nickServDao: NickServDao,
         val target = "javabot"
         val karma = getKarma(target) + 1
         val response = operation.handleMessage(message("~${target}++"))
-                assertEquals(response[0].value, Sofia.karmaOthersValue(target, karma, TEST_USER.nick))
+        assertEquals(response[0].value, Sofia.karmaOthersValue(target, karma, TEST_USER.nick))
     }
 
     fun changeOwnKarma() {


### PR DESCRIPTION
…requested target

i.e., "~karma FoO" should say "FoO has karma 0" and not the normalized "foo has karma 0"