### PR TITLE
Fix AbstractMethodError on startup from logback-access version mismatch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -248,6 +248,11 @@
             <artifactId>logback-classic</artifactId>
             <version>${logback.version}</version>
         </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-access</artifactId>
+            <version>${logback.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.jsoup</groupId>
@@ -470,7 +475,7 @@
         <jaxb.version>2.3.1</jaxb.version>
         <jsoup.version>1.23.2</jsoup.version>
         <kotlin.version>2.4.10</kotlin.version>
-        <logback.version>1.5.38</logback.version>
+        <logback.version>1.3.16</logback.version>
         <morphia.version>2.5.3</morphia.version>
         <okhttp.version>4.12.0</okhttp.version>
         <slf4j.version>2.0.19</slf4j.version>


### PR DESCRIPTION
## Summary

Fixes the startup crash:

```
java.lang.AbstractMethodError: Missing implementation of resolved method 'abstract java.util.Map getDefaultConverterSupplierMap()' of abstract class ch.qos.logback.core.pattern.PatternLayoutBase.
```

**Root cause:** `logback.version` was pinned to `1.5.38` (used by `logback-classic`/`logback-core`), but `dropwizard-request-logging:2.1.5` transitively pulls in `logback-access:1.2.11`. Logback-core added a new abstract method (`getDefaultConverterSupplierMap`) to `PatternLayoutBase` somewhere between `1.5.10` and `1.5.20`, and the old `logback-access:1.2.11` `PatternLayout` (compiled against the pre-1.5.20 API) doesn't implement it — so Dropwizard blows up building the access-log layout at startup.

Bumping `logback-access` up to match `1.5.38` isn't viable: every `logback-access` release from `1.5.7` onward is just a relocation stub to a new `ch.qos.logback.access:logback-access-common` module that depends on `jakarta.servlet`, which conflicts with Dropwizard 2.1.5's `javax.servlet`/Jetty 9 stack (confirmed — it breaks compilation of `JavabotApplication.kt`).

**Fix:** Pin `logback.version` down to `1.3.16` — the last release before the `logback-access` module relocated, still `javax.servlet`-based, and predates the new abstract method — and add an explicit `logback-access` dependency at the same version so all three logback artifacts (`logback-core`, `logback-classic`, `logback-access`) resolve consistently instead of relying on a mismatched transitive version.

## Verification

- `mvn dependency:tree -Dincludes=ch.qos.logback` now shows `logback-core`, `logback-classic`, and `logback-access` all resolving to `1.3.16` (previously `logback-core`/`logback-classic` were `1.5.38` while `logback-access` was transitively `1.2.11`).
- `mvn compile` and `mvn test-compile` pass cleanly.
- Reproduced the exact failing call from the stack trace (`ch.qos.logback.access.PatternLayout.start()`) against the project's resolved classpath — it now starts successfully instead of throwing `AbstractMethodError`.

## Test plan

- [x] `mvn compile`
- [x] `mvn test-compile`
- [x] Standalone repro of `ch.qos.logback.access.PatternLayout.start()` on the resolved classpath — no longer throws
- [ ] Start the bot end-to-end (requires MongoDB/IRC config not available in this sandbox) to confirm the app now boots past this point

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MHgbBRHGcwxWxffcXMH71A

---
_Generated by [Claude Code](https://claude.ai/code/session_01MHgbBRHGcwxWxffcXMH71A)_